### PR TITLE
add endpoint GET /api/unilateral/partners

### DIFF
--- a/account-integration-sample/controllers/unilateral/api.controller.js
+++ b/account-integration-sample/controllers/unilateral/api.controller.js
@@ -39,11 +39,19 @@ export const FetchCard = async (card_fetch_token, access_token) => {
 export const MERCHANTS = [{
   name: 'Lazada',
   url: 'https://www.lazada.sg',
-  clientId: '5gooe22dkk23f3nheika6p212',
-  clientSecret: '1816cbmasgd86usjcsl4eu65lns8bd3ul1938bcg2nsdkj39ui5r'
+  credentials: {
+    'https://auth.sandbox.openfabric.co/oauth2/token': {
+      clientId: '5gooe22dkk23f3nheika6p212',
+      clientSecret: '1816cbmasgd86usjcsl4eu65lns8bd3ul1938bcg2nsdkj39ui5r'
+    },
+    'https://auth.dev.openfabric.co/oauth2/token': {
+      clientId: '1mlc17v3o6rl6869q3bf26l5q1',
+      clientSecret: 'lsopq2kb796pdvj5g73tvk90n7j7os29tt1k211ut3ias3j8k2i'
+    }
+  }
 }]
 
-export const authorize = async (clientId, clientSecret, scope) => {
+export const authorize = async ({ clientId, clientSecret }, scope) => {
   const response = await fetch(
     of_auth_url, {
       method: 'POST',
@@ -56,16 +64,15 @@ export const authorize = async (clientId, clientSecret, scope) => {
       })
     }
   )
-  console.log(response.status)
   const data = await response.json()
   return data.access_token
 }
 
 export const listPartners = catchAsync(async (req, res) => {
   const data = await Promise.all(
-    MERCHANTS.map(async ({ clientId, clientSecret, ...merchant }) => {
+    MERCHANTS.map(async ({ credentials, ...merchant }) => {
       const accessToken = await authorize(
-        clientId, clientSecret,
+        credentials[of_auth_url],
         'resources/transactions.create'
       )
       return {

--- a/account-integration-sample/controllers/unilateral/api.controller.js
+++ b/account-integration-sample/controllers/unilateral/api.controller.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { of_issuer_url } from "../../lib/variables.js";
+import { of_issuer_url, of_auth_url } from "../../lib/variables.js";
 import { GetAccessToken } from "../../services/auth.js";
 import { catchAsync } from "../../utils/catchAsync";
 import * as transactionService from "../../services/of-transactions";
@@ -35,3 +35,44 @@ export const FetchCard = async (card_fetch_token, access_token) => {
     );
     return result.data;
 };
+
+export const MERCHANTS = [{
+  name: 'Lazada',
+  url: 'https://www.lazada.sg',
+  clientId: '5gooe22dkk23f3nheika6p212',
+  clientSecret: '1816cbmasgd86usjcsl4eu65lns8bd3ul1938bcg2nsdkj39ui5r'
+}]
+
+export const authorize = async (clientId, clientSecret, scope) => {
+  const response = await fetch(
+    of_auth_url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: new URLSearchParams({
+        grant_type: 'client_credentials',
+      })
+    }
+  )
+  console.log(response.status)
+  const data = await response.json()
+  return data.access_token
+}
+
+export const listPartners = catchAsync(async (req, res) => {
+  const data = await Promise.all(
+    MERCHANTS.map(async ({ clientId, clientSecret, ...merchant }) => {
+      const accessToken = await authorize(
+        clientId, clientSecret,
+        'resources/transactions.create'
+      )
+      return {
+        ...merchant,
+        accessToken,
+      }
+    })
+  )
+  res.json(data)
+})

--- a/account-integration-sample/routes/api/unilateral.route.js
+++ b/account-integration-sample/routes/api/unilateral.route.js
@@ -1,5 +1,9 @@
 import express from "express";
 import { unilateralController } from "../../controllers";
+
 const router = express.Router();
+
 router.route("/transactions").post(unilateralController.CreateTransaction);
+router.route("/partners").get(unilateralController.listPartners);
+
 export const Unilateral = router;


### PR DESCRIPTION
This PR adds `GET /api/unilateral/partners` to the Tenant integration sample. This is to support the Tenant Sample Android app, which will use the Unilateral SDK.